### PR TITLE
Fix require path for Socks5 client agents.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 'use strict';
 
-var Socks5ClientHttpAgent = require('./node_modules/socks5-http-client/lib/Agent');
-var Socks5ClientHttpsAgent = require('./node_modules/socks5-https-client/lib/Agent');
+var Socks5ClientHttpAgent = require('socks5-http-client/lib/Agent');
+var Socks5ClientHttpsAgent = require('socks5-https-client/lib/Agent');
 var request = require("request");
 var url = require("url");
 


### PR DESCRIPTION
When I install torrequest locally with:

``` bash
npm install torrequest
```

It attempts to look for the Socks5 clients in the wrong directory. Removing the `./node_modules/` from the front fixes that problem for me.
